### PR TITLE
SerializableなConsumerへの変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,8 +150,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>

--- a/src/main/java/com/experiments/wicket/Link/LambdaLink.java
+++ b/src/main/java/com/experiments/wicket/Link/LambdaLink.java
@@ -7,7 +7,7 @@ public class LambdaLink<T> extends Link<T>{
 	
 	private static final long serialVersionUID = -1L;
 
-	private Runnable clickEvent;
+	private SerializableConsumer<T> consumer;
 	
 	public LambdaLink(String id) {
 		super(id);
@@ -17,16 +17,16 @@ public class LambdaLink<T> extends Link<T>{
 		super(id, model);
 	}
 
-	public LambdaLink(String id, Runnable clickEvent) {
+	public LambdaLink(String id, SerializableConsumer<T> consumer) {
 		super(id);
-		this.clickEvent = clickEvent;
+		this.consumer = consumer;
 	}
 	
 	@Override
 	public void onClick() {
 
 		try{
-			clickEvent.run();
+		  consumer.accept(getModelObject());
 		}catch(NullPointerException e){
 		}
 	}

--- a/src/main/java/com/experiments/wicket/Link/SerializableConsumer.java
+++ b/src/main/java/com/experiments/wicket/Link/SerializableConsumer.java
@@ -1,0 +1,9 @@
+package com.experiments.wicket.Link;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface SerializableConsumer<T> extends Consumer<T>, Serializable {
+
+}

--- a/src/main/java/com/experiments/wicket/Link/page/LambdaLinkPage.java
+++ b/src/main/java/com/experiments/wicket/Link/page/LambdaLinkPage.java
@@ -4,14 +4,13 @@ import org.apache.wicket.markup.html.WebPage;
 
 import com.experiments.wicket.Link.LambdaLink;
 
-public class LambdaLinkPage extends WebPage {	
+public class LambdaLinkPage extends WebPage {
 
-	private static final long serialVersionUID = -5158423215891338365L;
+  private static final long serialVersionUID = -5158423215891338365L;
 
-	public LambdaLinkPage() {
-		
-		add(new LambdaLink<Void>(
-				"lambdaLink",() -> setResponsePage(FooPage.class)));
-		
-    }
+  public LambdaLinkPage() {
+
+    add(new LambdaLink<Void>(
+        "lambdaLink", model -> setResponsePage(FooPage.class)));
+  }
 }

--- a/src/test/java/com/experiments/wicket/link/page/LambdaLinkPageTest.java
+++ b/src/test/java/com/experiments/wicket/link/page/LambdaLinkPageTest.java
@@ -1,0 +1,35 @@
+package com.experiments.wicket.link.page;
+
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.experiments.wicket.WicketApplication;
+import com.experiments.wicket.Link.page.FooPage;
+import com.experiments.wicket.Link.page.LambdaLinkPage;
+
+/**
+ * Simple test using the WicketTester
+ */
+public class LambdaLinkPageTest
+{
+  private WicketTester tester;
+
+  @Before
+  public void setUp() {
+    tester = new WicketTester(new WicketApplication());
+  }
+
+  @Test
+  public void ページの表示に成功する() {
+    tester.startPage(LambdaLinkPage.class);
+    tester.assertRenderedPage(LambdaLinkPage.class);
+  }
+
+  @Test
+  public void リンクを押すとFooPageに移動する() {
+    tester.startPage(LambdaLinkPage.class);
+    tester.clickLink("lambdaLink");
+    tester.assertRenderedPage(FooPage.class);
+  }
+}


### PR DESCRIPTION
Lambda式では、thisのスコープがLinkではなくてPageになってしまうので、RunnableだとSerializableにしてもonClick内からgetModel/getModelObjectできなくなってしまう。
そのため、Modelを格納できるConsumerに変更し、これをonClickで実行できるようにする。